### PR TITLE
chore: add CODEOWNERS and tighten reuse workflow triggers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Code owners for the external-arbiter-operator repository.
+#
+# These owners will be the default owners for everything in the repo and
+# will be automatically requested for review when someone opens a pull
+# request. A review from any one of the listed owners is sufficient to
+# satisfy the code-owner review requirement (configured via repository
+# ruleset: "Require review from Code Owners" with required approving
+# review count = 1).
+#
+# Last matching pattern takes precedence.
+
+* @senolcolak @sumitarora2786

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -3,12 +3,19 @@
 
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v6
+      - uses: actions/checkout@v6
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v6

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -16,6 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v6
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: "35 1 * * *"
 
+permissions: {}
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest
@@ -13,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 90


### PR DESCRIPTION
## Summary

Two governance / hygiene improvements:

### `.github/CODEOWNERS`
Assigns @senolcolak (Senol Colak) and @sumitarora2786 (Sumit Arora) as default owners for the entire repository.

GitHub CODEOWNERS semantics: when multiple owners are listed on the same line, **a single review from any one of them satisfies the code-owner requirement**. To enforce this on `main`, the repository ruleset must additionally have:
- `Require a pull request before merging` ✓
- `Required approving review count` = **1**
- `Require review from Code Owners` ✓

The matching ruleset is being applied separately (it's a settings change, not part of this PR).

### `.github/workflows/reuse.yaml`
- **Triggers**: changed from `on: [push, pull_request]` (which causes duplicate runs on every push to a feature branch with an open PR) to `push` only on `main` and `pull_request` targeting `main`. This eliminates the duplicate runs while preserving validation on PRs and post-merge runs on `main`.
- **Permissions**: added explicit workflow-level `permissions: contents: read` (least privilege).

## Verification
- Both GitHub handles resolved against the `cobaltcore-dev` org.
- YAML is valid.
- DCO sign-off included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration files for code ownership and CI/CD workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->